### PR TITLE
Add user chat cleanup endpoint

### DIFF
--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -49,4 +49,9 @@ export class ChatController {
   removeChat(@Param('id') id: string) {
     return this.chatService.deleteChat(id);
   }
+
+  @Delete('user/:id')
+  removeUserChats(@Param('id') id: string) {
+    return this.chatService.deleteUserChats(id);
+  }
 }

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -65,6 +65,18 @@ export class ChatService {
     return await this.chatModel.findByIdAndDelete(id).exec();
   }
 
+  async deleteUserChats(userId: string): Promise<any> {
+    const chats = await this.chatModel
+      .find({ $or: [{ sender: userId }, { recipient: userId }] })
+      .exec();
+
+    const chatIds = chats.map((c) => c._id);
+
+    await this.messageModel.deleteMany({ chat: { $in: chatIds } }).exec();
+
+    return await this.chatModel.deleteMany({ _id: { $in: chatIds } }).exec();
+  }
+
   async getMessagesByChatId(chatId): Promise<Message[]> {
     console.log(chatId);
     return this.messageModel


### PR DESCRIPTION
## Summary
- expose ChatService method to remove all conversations for a user
- add `DELETE /chat/user/:id` endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628087e424833392ab1b8f66050eb5