### PR TITLE
Add HEIC to JPEG conversion endpoint

### DIFF
--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -3,10 +3,12 @@ import {
   Post,
   UploadedFile,
   UseInterceptors,
+  Res,
 } from '@nestjs/common';
 import { FileService } from './file.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { FileResponseEl } from './dto/file-response-el';
+import { Response } from 'express';
 
 @Controller('file')
 export class FileController {
@@ -18,5 +20,19 @@ export class FileController {
     @UploadedFile() files: Express.Multer.File,
   ): Promise<FileResponseEl[]> {
     return this.fileService.saveFile([files]);
+  }
+
+  @Post('heic-to-jpeg')
+  @UseInterceptors(FileInterceptor('file'))
+  async heicToJpeg(
+    @UploadedFile() file: Express.Multer.File,
+    @Res() res: Response,
+  ): Promise<void> {
+    const buffer = await this.fileService.convertHeicToJpeg(file.buffer);
+    res.set({
+      'Content-Type': 'image/jpeg',
+      'Content-Disposition': `attachment; filename=${file.originalname?.split('.')[0] || 'image'}.jpg`,
+    });
+    res.send(buffer);
   }
 }

--- a/src/file/file.service.ts
+++ b/src/file/file.service.ts
@@ -58,6 +58,10 @@ export class FileService {
     return sharp(file).webp().toBuffer();
   }
 
+  convertHeicToJpeg(file: Buffer): Promise<Buffer> {
+    return sharp(file).jpeg().toBuffer();
+  }
+
   async saveFile(files: MFile[]): Promise<FileResponseEl[]> {
     const dateFolder = format(new Date(), 'yyyy-MM-dd');
     const uploadFolder = `${path}/uploads/${dateFolder}`;


### PR DESCRIPTION
## Summary
- add conversion of HEIC images to JPEG in `FileService`
- expose new `POST /file/heic-to-jpeg` endpoint in `FileController` to return converted file

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f3fd7b3083338b88737351b549bf