### PR TITLE
Fix findAll when services missing

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -112,7 +112,7 @@ export class UserService {
                 {
                   $size: {
                     $filter: {
-                      input: '$services',
+                      input: { $ifNull: ['$services', []] },
                       as: 's',
                       cond: {
                         $and: [


### PR DESCRIPTION
## Summary
- prevent aggregation errors when `services` field is missing

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686672ab37e883339ab41c44dc07ac90