### PR TITLE
Fix $limit with numeric parsing

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -83,6 +83,7 @@ export class UserService {
     withPhoto = '',
     limit = 12,
   }) {
+    limit = parseInt(String(limit), 10);
     const filter: any = { status: UserStatus.ACTIVE };
 
     if (online) {


### PR DESCRIPTION
## Summary
- parse `limit` query param to a number before using it in an aggregation

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68667d45d7208333baae471a28c117be