### PR TITLE
Fix top user filtering

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -117,7 +117,7 @@ export class UserService {
                       as: 's',
                       cond: {
                         $and: [
-                          { $eq: ['$$s._id', TOP_ID] },
+                          { $eq: [{ $toString: '$$s._id' }, TOP_ID] },
                           { $gt: ['$$s.expiredAt', now] },
                         ],
                       },
@@ -374,6 +374,7 @@ export class UserService {
     quantity = 0,
     period,
   }: BuyServiceDto) {
+    serviceId = serviceId.toString();
     const user = await this.userModel.findOne({ _id: userId });
 
     if (!user) throw new HttpException('User not found', HttpStatus.NOT_FOUND);


### PR DESCRIPTION
## Summary
- ensure service IDs are stored as strings when buying services
- normalize top-filter comparison by casting service `_id`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866823d3ec88333bad2a021f869abe5